### PR TITLE
Clarify docs for oauth/token parameters

### DIFF
--- a/resources/views/vendor/apidoc/partials/info.blade.php
+++ b/resources/views/vendor/apidoc/partials/info.blade.php
@@ -124,7 +124,7 @@ fetch("{!! route('oauth.passport.token') !!}", {
 
 `POST {!! route('oauth.passport.token') !!}`
 
-Parameters
+Form-data parameters passed in the request body:
 
 Name          | Type   | Description
 --------------|--------|-------------------------------


### PR DESCRIPTION
Add info about required params should be passed in request body.
For #5872